### PR TITLE
Check for A==0 / B==0.

### DIFF
--- a/lib/srp.js
+++ b/lib/srp.js
@@ -4,6 +4,8 @@ const crypto = require('crypto'),
       assert = require('assert'),
       ALG = config.get('alg_name');
 
+const zero = bigint(0);
+
 /*
  * If a conversion is explicitly specified with the operator PAD(),
  * the integer will first be implicitly converted, then the resultant
@@ -192,6 +194,8 @@ var getu = exports.getu = function getu(A, B, N, alg) {
  * returns: bigint
  */
 var client_getS = exports.client_getS = function client_getS(s, I, P, N, g, a, B, alg) {
+  if (zero.ge(B) || N.le(B))
+    throw new Error("invalid server-supplied 'B', must be 1..N-1");
   var A = getA(g, a, N);
   var u = getu(A, B, N, alg);
   var k = getk(N, g, alg);
@@ -213,6 +217,8 @@ var client_getS = exports.client_getS = function client_getS(s, I, P, N, g, a, B
  * returns: bigint
  */
 var server_getS = exports.server_getS = function server_getS(s, v, N, g, A, b, alg) {
+  if (zero.ge(A) || N.le(A))
+    throw new Error("invalid client-supplied 'A', must be 1..N-1");
   var k = getk(N, g, alg);
   var B = getB(v, g, b, N, alg);
   var u = getu(A, B, N, alg);

--- a/test/test_srp.js
+++ b/test/test_srp.js
@@ -72,7 +72,40 @@ vows.describe("srp.js")
 
         "by client and server are equal": function() {
           assert(S_server.eq(S_client));
+        },
+
+        "server rejects bad A": function() {
+          // client's "A" must be 1..N-1 . Reject 0 and N and 2*N.
+          var Azero = bigint("00", 16);
+          var AN = N;
+          var A2N = N.mul(2);
+          assert.throws(function() {
+            srp.server_getS(s, v, N, g, Azero, b, ALG_NAME);
+          }, Error);
+          assert.throws(function() {
+            srp.server_getS(s, v, N, g, AN, b, ALG_NAME);
+          }, Error);
+          assert.throws(function() {
+            srp.server_getS(s, v, N, g, A2N, b, ALG_NAME);
+          }, Error);
+        },
+
+        "client rejects bad B": function() {
+          // server's "B" must be 1..N-1 . Reject 0 and N and 2*N.
+          var Bzero = bigint("00", 16);
+          var BN = N;
+          var B2N = N.mul(2);
+          assert.throws(function() {
+            srp.client_getS(s, I, P, N, g, a, Bzero, ALG_NAME);
+          }, Error);
+          assert.throws(function() {
+            srp.client_getS(s, I, P, N, g, a, BN, ALG_NAME);
+          }, Error);
+          assert.throws(function() {
+            srp.client_getS(s, I, P, N, g, a, B2N, ALG_NAME);
+          }, Error);
         }
+
       }
     }
   }


### PR DESCRIPTION
Unlike #9, this PR does _not_ include Danny's other improvements. It just has the group-element check.

(note that this means it fails tests every once in a while, because of the padding bugs that Danny's Buffer-ification fixed).

cc @ckarlof
