### PR TITLE
add 'getM' (and update test vectors in the process)

### DIFF
--- a/lib/srp.js
+++ b/lib/srp.js
@@ -266,6 +266,16 @@ function getK(S, N, alg) {
       .digest();
 };
 
+function getM(A, B, S, N, alg) {
+  alg = alg || ALG;
+  return crypto
+    .createHash(alg)
+    .update(pad(A, N))
+    .update(pad(B, N))
+    .update(pad(S, N))
+    .digest();
+}
+
 module.exports = {
   getx: function (s, I, P, alg) {
     return getx(s, I, P, alg).toBuffer()
@@ -322,5 +332,6 @@ module.exports = {
   },
   getu: getuBuffer,
   getk: getkBuffer,
-  getK: getK
+  getK: getK,
+  getM: getM
 }

--- a/test/test_picl_vectors.js
+++ b/test/test_picl_vectors.js
@@ -168,6 +168,10 @@ vows.describe('picl vectors')
           hexequal(buf2048(S), expected.S);
         },
 
+        'M': function(S) {
+          hexequal(srp.getM(expected.A, expected.B, S, params.N, ALG), expected.M1);
+        },
+
         'K': function(S) {
           hexequal(srp.getK(S, params.N, ALG), expected.K);
         }
@@ -181,6 +185,10 @@ vows.describe('picl vectors')
 
         'S': function(S) {
           hexequal(buf2048(S), expected.S);
+        },
+
+        'M': function(S) {
+          hexequal(srp.getM(expected.A, expected.B, S, params.N, ALG), expected.M1);
         },
 
         'K': function(S) {

--- a/test/test_srp.js
+++ b/test/test_srp.js
@@ -74,6 +74,13 @@ vows.describe("srp.js")
           assert.equal(S_server.toString('hex'), S_client.toString('hex'));
         },
 
+        "and K and M1 can be generated": function() {
+          var K = srp.getK(S_client, N, ALG_NAME);
+          var M1 = srp.getM(A, B, S_client, N, ALG_NAME);
+          assert(K.length > 0);
+          assert (M1.length > 0);
+        },
+
         "server rejects bad A": function() {
           // client's "A" must be 1..N-1 . Reject 0 and N and 2*N.
           var Azero = new Buffer(N.length);


### PR DESCRIPTION
This adds the `srp.getM` function, which provides the key-confirmation message (typically sent from the client to the server, to prove that it derived the same shared key as the server did).

This patch series starts by rearranging the PICL tests into a cleaner form, then updating the test vectors to the current set. This gives us a well-defined "M1" value to test against. The final patch actually adds `getM`.

This is built upon the 'buffers' branch from #17 in the assumption that that branch will land first.
