### PR TITLE
Update bignum dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "readmeFilename": "README.md",
 
   "dependencies": {
-    "bignum": "0.6.1"
+    "bignum": "0.6.2"
   },
 
   "devDependencies": {


### PR DESCRIPTION
bignum 0.6.2 installs on Windows, while bignum 0.6.1 does not.
