### PR TITLE
Update bignum dependency to 0.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "readmeFilename": "README.md",
 
   "dependencies": {
-    "bignum": "0.6.2"
+    "bignum": "0.9.2"
   },
 
   "devDependencies": {


### PR DESCRIPTION
This updates the bignum dependency to version 0.9.2, so node-srp can be successfully installed on node v0.12+