### PR TITLE
Remove Dependency on NodeJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ node_modules
 
 # awsbox setup notes
 awsbox_notes.txt
+
+# IntelliJ
+.idea

--- a/lib/bignum.js
+++ b/lib/bignum.js
@@ -1,0 +1,63 @@
+var Buffer = require('./buffer');
+var jsbn = require('jsbn');
+
+var BigInteger = jsbn.BigInteger;
+BigInteger.prototype.toBuffer = function () {
+    var h = this.toString(16);
+
+    // Fix odd-length hex values from BigInteger
+    if (h.length % 2 === 1) {
+        h = '0' + h;
+    }
+
+    return Buffer.from(h, 'hex');
+};
+
+function ensureBI (n) {
+    if (n.constructor.name !== 'BigInteger') {
+        n = bignum(n);
+    }
+
+    return n;
+}
+
+BigInteger.prototype.oldAdd = BigInteger.prototype.add;
+BigInteger.prototype.add = function (n) {
+    return this.oldAdd(ensureBI(n));
+};
+
+BigInteger.prototype.mul = function (n) {
+    return this.multiply(ensureBI(n));
+};
+
+BigInteger.prototype.sub = function (n) {
+    return this.subtract(ensureBI(n));
+};
+
+BigInteger.prototype.powm = function (n, m) {
+    return this.modPow(ensureBI(n), ensureBI(m));
+};
+
+BigInteger.prototype.eq = function (n) {
+    return this.equals(ensureBI(n));
+};
+
+BigInteger.prototype.ge = function (n) {
+  return this.compareTo(n) >= 0;
+};
+
+BigInteger.prototype.le = function (n) {
+    return this.compareTo(n) <= 0;
+};
+
+function fromBuffer (buffer) {
+    var hex = buffer.toString('hex');
+    return new BigInteger(hex, 16);
+}
+
+function bignum (v, r) {
+    return new BigInteger(v.toString(), r)
+}
+
+module.exports = bignum;
+module.exports.fromBuffer = fromBuffer;

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1,0 +1,5 @@
+if (!Buffer) {
+    global.Buffer = require('buffer/').Buffer;
+}
+
+module.exports = Buffer;

--- a/lib/params.js
+++ b/lib/params.js
@@ -14,7 +14,7 @@
 // since these are meant to be used internally, all values are numbers. If
 // you want to add parameter sets, you'll need to convert them to bignums.
 
-const bignum = require('bignum');
+const bignum = require('./bignum');
 
 function hex(s) {
     return bignum(s.split(/\s/).join(''), 16);

--- a/lib/srp.js
+++ b/lib/srp.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto'),
-      bignum = require('bignum'),
+      bignum = require('./bignum'),
+      Buffer = require('./buffer'),
       assert = require('assert');
 
 const zero = bignum(0);
@@ -65,7 +66,7 @@ function assertIsNBuffer(arg, params, argname) {
 }
 
 function assertIsBignum(arg) {
-  assert.equal(arg.constructor.name, "BigNum");
+  assert.equal(arg.constructor.name, "BigInteger");
 }
 
 /*

--- a/package.json
+++ b/package.json
@@ -2,26 +2,21 @@
   "name": "srp",
   "description": "Secure Remote Password (SRP)",
   "version": "0.2.0",
-
   "main": "index.js",
-
   "scripts": {
     "test": "vows test/test*.js --spec"
   },
-
   "repository": {
     "type": "git",
     "url": "https://github.com/mozilla/node-srp"
   },
-
   "author": "Brian Warner <warner-node-srp@lothar.com>",
   "licence": "MIT",
   "readmeFilename": "README.md",
-
   "dependencies": {
-    "bignum": "0.9.2"
+    "buffer": "^5.0.0",
+    "jsbn": "^0.1.0"
   },
-
   "devDependencies": {
     "vows": "0.7.0"
   }

--- a/test/speed.js
+++ b/test/speed.js
@@ -1,5 +1,6 @@
 const params = require('../lib/params'),
       srp = require('../lib/srp'),
+      Buffer = require('../lib/buffer'),
       s = new Buffer("salty"),
       I = new Buffer("alice"),
       P = new Buffer("password123"),

--- a/test/test_picl_vectors.js
+++ b/test/test_picl_vectors.js
@@ -1,6 +1,7 @@
 const vows = require('vows'),
       assert = require('assert'),
-      bignum = require('bignum'),
+      bignum = require('../lib/bignum'),
+      Buffer = require('../lib/buffer'),
       srp = require('../lib/srp');
 
 /*

--- a/test/test_rfc_5054.js
+++ b/test/test_rfc_5054.js
@@ -1,6 +1,7 @@
 const vows = require('vows'),
       assert = require('assert'),
       srp = require('../lib/srp'),
+      Buffer = require('../lib/buffer'),
       params = srp.params['1024'];
 
 /*

--- a/test/test_srp.js
+++ b/test/test_srp.js
@@ -2,6 +2,7 @@ const vows = require('vows'),
       assert = require('assert'),
       srp = require('../lib/srp'),
       params = srp.params[4096],
+      Buffer = require('../lib/buffer'),
 
       salt = new Buffer("salty"),
       identity = new Buffer("alice"),


### PR DESCRIPTION
What was done
- Removed `bignum` dependency and replaced with `jsbn`
- Include browser-compatible `buffer` library
- Created alias functions on `jsbn.BigInteger` so minimal code changes were required
  - Functions like `sub` --> `subtract`, `eq` --> `equals`, etc

All tests pass so it should be safe to use!
